### PR TITLE
Switch example to python3

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,4 +1,4 @@
-FROM bitnami/python:2 as builder
+FROM bitnami/python:3 as builder
 COPY . /app
 WORKDIR /app
 RUN virtualenv . && \
@@ -6,7 +6,7 @@ RUN virtualenv . && \
     pip install django && \
     python manage.py migrate
 
-FROM bitnami/python:2-prod
+FROM bitnami/python:3-prod
 COPY --from=builder /app /app
 WORKDIR /app
 EXPOSE 8000


### PR DESCRIPTION
Python2 is deprecated and using it  spits out a clear deprecation warning:

```
DEPRECATION: Python 2.7 will reach the end of its life on January 1st, 2020. Please upgrade your Python as Python 2.7 won't be maintained after that date. A future version of pip will drop support for Python 2.7. More details about Python 2 support in pip, can be found at https://pip.pypa.io/en/latest/development/release-process/#python-2-support
```

Furthermore, January 1st 2020 is imminent