### PR TITLE
Switch to python3 venv

### DIFF
--- a/example/Dockerfile
+++ b/example/Dockerfile
@@ -1,19 +1,22 @@
 FROM bitnami/python:3 as builder
+ENV PATH="/app/.venv/bin:${PATH}"
+WORKDIR /app
+
+RUN python -m venv .venv
 
 COPY requirements.txt /app
-
-WORKDIR /app
-RUN virtualenv . && \
-    . bin/activate && \
-    pip install -r requirements.txt
+RUN pip install -r requirements.txt
 
 COPY . /app
+RUN python manage.py migrate
 
-RUN . bin/activate && \
-    python manage.py migrate
-
+# The production image is constructed with a smaller, production grade
+# base image, and your code built in the previous build stage.
 FROM bitnami/python:3-prod
-COPY --from=builder /app /app
+ENV PATH="/app/.venv/bin:${PATH}"
 WORKDIR /app
+
+COPY --from=builder /app /app
+
 EXPOSE 8000
-CMD bash -c "source bin/activate && python manage.py runserver 0:8000"
+CMD python manage.py runserver 0:8000


### PR DESCRIPTION
Python3 comes with a native "virtual env" feature called `venv`.

Furthermore, the way we used virtual env is brittle because every time a user wants to add a RUN stanza she needs to remember to run `. bin/activate` or else accidentally run python commands in the wrong venv.

This PR uses a different approach, by just prepending the `bin` dir to the PATH (which is basically what `activate` does anyway) with an `ENV` stanza, thus shared by all commands, including in further derived images.